### PR TITLE
Enable long, GNU style options RE: issue-1

### DIFF
--- a/test/fixture/help.stdio
+++ b/test/fixture/help.stdio
@@ -2,9 +2,10 @@ B3BP:STDIO_REPLACE_DATETIMES
 
  Help using {root}/main.sh
 
-  -f   [arg] Filename to process. Required.
-  -t   [arg] Location of tempfile. Default="{tmpdir}/bar"
-  -d         Enables debug mode
-  -h         This page
+  -f --file  [arg] Filename to process. Required.
+  -t --temp  [arg] Location of tempfile. Default="{tmpdir}/bar"
+  -v               Enable verbose mode, print script as it is executed
+  -d --debug       Enables debug mode
+  -h --help        This page
 
 {datetime} UTC [32m[     info][0m Cleaning up. Done


### PR DESCRIPTION
Pending final review and CI tests, @kvz please feel free to merge

 - Enable long, GNU style options, fixes #1
 - :warning: *CAVEAT* A short option must be preset for every long option;
   but every short option need *not* have a long option
 - No BASH 4 features were added, works with bash 3 and standard sed and
   awk
 - `--` is still respected as the separator between options and arguments
 - Use `awk` only instead of `awk` and `sed` for parsing short options
   from usage string
 - Enable `errexit`, `nounset` and `pipefail` at the top