### PR TITLE
Bypass npm on Travis so we don't require node at all

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,14 @@
-# We're installing nodejs by hand, as that's not supported on
-# Travis OSX testing yet. So language is generic here:
 language: generic
-env:
-  global:
-    - NODE_VERSION='4.2.1'
 matrix:
   include:
     - os: linux
       sudo: false
     - os: osx
 install:
-  # Install acceptance test dependencies
+  # Install acceptance test dependencies for OSX
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then which gsed || brew install gnu-sed; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then which gtimeout || brew install coreutils; fi
-  # Install nvm
-  - rm -rf ~/.nvm
-  - git clone https://github.com/creationix/nvm.git ~/.nvm
-  - source ~/.nvm/nvm.sh
-  # Install Node.js
-  - nvm install $NODE_VERSION
-  # Install Node modules
-  - npm install
   # Show versions used
-  - node --version
   - bash --version
-script: npm run test
+script: test/acceptance.sh


### PR DESCRIPTION
@zbeekman The thought occurred to me that the Node dependency is mostly for developer convenience, but not a hard requirement on Travis. Travis is now calling the acceptance test script directly without going through npm scripts, speeding up the builds greatly.

I'm sorry you invested so real effort into getting Node installed cross-platform, only to see it removed by me now. But I hope you'll agree this is a win for the project, and that the main objective you set out for: cross-platform tests, is still very much alive and even served by this