### PR TITLE
Mangle long-option names to allow dashes

### DIFF
--- a/test/fixture/main-help.stdio
+++ b/test/fixture/main-help.stdio
@@ -7,5 +7,7 @@ B3BP:STDIO_REPLACE_DATETIMES
   -v               Enable verbose mode, print script as it is executed
   -d --debug       Enables debug mode
   -h --help        This page
+  -n --no-color    Disable color output
+  -1 --one         Do just one thing
 
 {datetime} UTC [32m[     info][0m Cleaning up. Done


### PR DESCRIPTION
Fixes problem where long options with dashes, like `--no-color` were
 broken. This was due to the fact that bash variable names must match
 `[_a-zA-Z][_0-9a-zA-Z]*` and the usage parsing and option handling was
 trying to create variables with dashes in their names. Short of
 employing Bash4 associative arrays, "name mangling" seemed like the
 best solution to this problem.

Solution: map dashes to underscores when creating bash variables in the
script that correspond to long option flags. The downside of this is
that `--no_color` and `--no-color` will collide, but users expecting to
use options that are identical except one has an underscore and the
other has a dash deserve the ensuing confusion.

See discussion on #7, especially @kvz's first comment