### PR TITLE
Make the license less restrictive. See #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Please see the [CHANGELOG.md](./CHANGELOG.md) file.
 
 ## master (Unreleased)
 
+- Make license more permissive by not requiring distribution of the LICENSE file if the copyright & attribution comments are left in tact
 - Respect `--no-color` by setting the NO_COLOR flag in `main.sh` (#25, thx @gdevenyi)
 - Split out changelog into separate file
 - Added a [FAQ](./FAQ.md) (#15, #14, thanks @rouson)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Please see the [CHANGELOG.md](./CHANGELOG.md) file.
 
 ## master (Unreleased)
 
-- Make license more permissive by not requiring distribution of the LICENSE file if the copyright & attribution comments are left in tact
+- Make license more permissive by not requiring distribution of the LICENSE file if the copyright & attribution comments are left intact
 - Respect `--no-color` by setting the NO_COLOR flag in `main.sh` (#25, thx @gdevenyi)
 - Split out changelog into separate file
 - Added a [FAQ](./FAQ.md) (#15, #14, thanks @rouson)

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 Kevin van Zonneveld
+Copyright (c) 2013 Kevin van Zonneveld and contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -9,8 +9,10 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The copyright notice with a link to this LICENSE and author attribution
+comments in the source code files shall be included in all copies or
+substantial portions of the Software. You do not have to
+redistribute this LICENSE itself.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/LICENSE
+++ b/LICENSE
@@ -9,10 +9,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The copyright notice with a link to this LICENSE and author attribution
-comments in the source code files shall be included in all copies or
-substantial portions of the Software. You do not have to
-redistribute this LICENSE itself.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,

--- a/README.md
+++ b/README.md
@@ -124,4 +124,4 @@ Please see the [FAQ.md](./FAQ.md) file.
 ## License
 
 Copyright (c) 2013 Kevin van Zonneveld, [http://kvz.io](http://kvz.io)  
-Licensed under MIT: [http://kvz.io/licenses/LICENSE-MIT](http://kvz.io/licenses/LICENSE-MIT)
+Licensed under MIT: [https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Overview
 
-When hacking up BASH scripts, I often find there are some
+When hacking up Bash scripts, I often find there are some
 higher level things like logging, configuration, command-line argument
 parsing that:
 
@@ -125,5 +125,7 @@ Please see the [FAQ.md](./FAQ.md) file.
 
 ## License
 
-Copyright (c) 2013 Kevin van Zonneveld, [http://kvz.io](http://kvz.io)  
-Licensed under MIT: [https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+Copyright (c) 2013 Kevin van Zonneveld and [contributors](https://github.com/kvz/bash3boilerplate#authors)
+Licensed under [MIT](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+You are not obligated to bundle the LICENSE file with your b3bp projects as long
+as you leave these references intact.

--- a/README.md
+++ b/README.md
@@ -112,8 +112,9 @@ Please see the [FAQ.md](./FAQ.md) file.
 - [Kevin van Zonneveld](http://kvz.io)
 - [Izaak Beekman](https://izaakbeekman.com/)
 - [Alexander Rathai](mailto:<Alexander.Rathai@gmail.com>)
-- [Dr. Damian Rouson](http://www.sourceryinstitute.org/) (documentation)
+- [Dr. Damian Rouson](http://www.sourceryinstitute.org/) (documentation, feedback)
 - [Gabriel A. Devenyi](http://staticwave.ca/) (feedback)
+- [@bravo-kernel](https://github.com/bravo-kernel) (feedback)
 
 ## Sponsoring
 

--- a/main.sh
+++ b/main.sh
@@ -24,10 +24,10 @@
 #
 #  LOG_LEVEL=7 ./main.sh -f /tmp/x -d
 #
-# Licensed under MIT with a less restrictive clause that excepts you of
-# redistributing the LICENSE file as long as you leave this comment in tact
-# (https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
 # Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
+# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
+# You are not obligated to ship the license file with your b3bp projects as long
+# as you leave the above comments intact.
 
 
 ### Configuration

--- a/main.sh
+++ b/main.sh
@@ -53,6 +53,8 @@ NO_COLOR="${NO_COLOR:-}"    # true = disable color. otherwise autodetected
 # - A short option must be preset for every long option; but every short option
 #   need not have a long option
 # - `--` is respected as the separator between options and arguments
+# - We do not bash-expand defaults, so setting '~/app' as a default will not resolve to ${HOME}.
+#   you can use bash variables to work around this (so use ${HOME} instead)
 read -r -d '' usage <<-'EOF' || true # exits non-zero when EOF encountered
   -f --file  [arg] Filename to process. Required.
   -t --temp  [arg] Location of tempfile. Default="/tmp/bar"

--- a/main.sh
+++ b/main.sh
@@ -24,8 +24,10 @@
 #
 #  LOG_LEVEL=7 ./main.sh -f /tmp/x -d
 #
-# Licensed under MIT
-# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io)
+# Licensed under MIT with a less restrictive clause that excepts you of
+# redistributing the LICENSE file as long as you leave this comment in tact
+# (https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
 
 
 ### Configuration

--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -29,10 +29,10 @@
 #
 #  ini_val.sh data.ini connection.host 127.0.0.1
 #
-# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
-# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
-# You are not obligated to ship the license file with your b3bp projects as long
-# as you leave the above comments intact.
+# Copyright (c) 2013 Kevin van Zonneveld and [contributors](https://github.com/kvz/bash3boilerplate#authors)
+# Licensed under [MIT](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact.
 
 function ini_val() {
   local file="${1:-}"

--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -29,8 +29,10 @@
 #
 #  ini_val.sh data.ini connection.host 127.0.0.1
 #
-# Licensed under MIT
-# Copyright (c) 2016 Kevin van Zonneveld (http://kvz.io)
+# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
+# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
+# You are not obligated to ship the license file with your b3bp projects as long
+# as you leave the above comments intact.
 
 function ini_val() {
   local file="${1:-}"

--- a/src/megamount.sh
+++ b/src/megamount.sh
@@ -31,10 +31,10 @@
 #
 #  megamount.sh smb://janedoe:abc123@192.168.0.1/documents /mnt/documents
 #
-# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
-# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
-# You are not obligated to ship the license file with your b3bp projects as long
-# as you leave the above comments intact.
+# Copyright (c) 2013 Kevin van Zonneveld and [contributors](https://github.com/kvz/bash3boilerplate#authors)
+# Licensed under [MIT](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact.
 
 __dir=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
 source "${__dir}/parse_url.sh"

--- a/src/megamount.sh
+++ b/src/megamount.sh
@@ -31,8 +31,10 @@
 #
 #  megamount.sh smb://janedoe:abc123@192.168.0.1/documents /mnt/documents
 #
-# Licensed under MIT
-# Copyright (c) 2016 Kevin van Zonneveld (http://kvz.io)
+# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
+# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
+# You are not obligated to ship the license file with your b3bp projects as long
+# as you leave the above comments intact.
 
 __dir=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
 source "${__dir}/parse_url.sh"

--- a/src/parse_url.sh
+++ b/src/parse_url.sh
@@ -28,10 +28,10 @@
 #
 #  parse_url.sh 'http://johndoe:abc123@example.com:8080/index.html'
 #
-# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
-# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
-# You are not obligated to ship the license file with your b3bp projects as long
-# as you leave the above comments intact.
+# Copyright (c) 2013 Kevin van Zonneveld and [contributors](https://github.com/kvz/bash3boilerplate#authors)
+# Licensed under [MIT](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact.
 
 function parse_url() {
   local parse="${1}"

--- a/src/parse_url.sh
+++ b/src/parse_url.sh
@@ -28,8 +28,10 @@
 #
 #  parse_url.sh 'http://johndoe:abc123@example.com:8080/index.html'
 #
-# Licensed under MIT
-# Copyright (c) 2016 Kevin van Zonneveld (http://kvz.io)
+# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
+# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
+# You are not obligated to ship the license file with your b3bp projects as long
+# as you leave the above comments intact.
 
 function parse_url() {
   local parse="${1}"

--- a/src/templater.sh
+++ b/src/templater.sh
@@ -27,10 +27,10 @@
 #
 #  ALLOW_REMAINDERS=1 templater.sh input.cfg output.cfg
 #
-# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
-# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
-# You are not obligated to ship the license file with your b3bp projects as long
-# as you leave the above comments intact.
+# Copyright (c) 2013 Kevin van Zonneveld and [contributors](https://github.com/kvz/bash3boilerplate#authors)
+# Licensed under [MIT](https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE)
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact.
 
 function templater() {
   ALLOW_REMAINDERS="${ALLOW_REMAINDERS:-0}"

--- a/src/templater.sh
+++ b/src/templater.sh
@@ -27,8 +27,10 @@
 #
 #  ALLOW_REMAINDERS=1 templater.sh input.cfg output.cfg
 #
-# Licensed under MIT
-# Copyright (c) 2016 Kevin van Zonneveld (http://kvz.io)
+# Copyright (c) 2013 Kevin van Zonneveld (http://kvz.io) and contributors
+# Licensed under MIT: https://raw.githubusercontent.com/kvz/bash3boilerplate/master/LICENSE
+# You are not obligated to ship the license file with your b3bp projects as long
+# as you leave the above comments intact.
 
 function templater() {
   ALLOW_REMAINDERS="${ALLOW_REMAINDERS:-0}"


### PR DESCRIPTION
So that people can use _just_ main.sh without bothering with also
distributing the license