### PR TITLE
cleanup environment variables.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -106,41 +106,41 @@ read -r -d '' __helptext <<-'EOF' || true # exits non-zero when EOF encountered
 EOF
 
 # Translate usage string -> getopts arguments, and set $arg_<flag> defaults
-while read line; do
+while read __b3bp_tmp_line; do
   # fetch single character version of option string
-  opt="$(echo "${line}" |awk '{print $1}' |sed -e 's#^-##')"
+  __b3bp_tmp_opt="$(echo "${__b3bp_tmp_line}" |awk '{print $1}' |sed -e 's#^-##')"
 
   # fetch long version if present
-  long_opt="$(echo "${line}" |awk '/\-\-/ {print $2}' |sed -e 's#^--##')"
-  long_opt_mangled="$(sed 's#-#_#g' <<< $long_opt)"
+  __b3bp_tmp_long_opt="$(echo "${__b3bp_tmp_line}" |awk '/\-\-/ {print $2}' |sed -e 's#^--##')"
+  __b3bp_tmp_long_opt_mangled="$(sed 's#-#_#g' <<< $__b3bp_tmp_long_opt)"
 
   # map long name back to short name
-  varname="short_opt_${long_opt_mangled}"
-  eval "${varname}=\"${opt}\""
+  __b3bp_tmp_varname="__b3bp_tmp_short_opt_${__b3bp_tmp_long_opt_mangled}"
+  eval "${__b3bp_tmp_varname}=\"${__b3bp_tmp_opt}\""
 
   # check if option takes an argument
-  varname="has_arg_${opt}"
-  if ! echo "${line}" |egrep '\[.*\]' >/dev/null 2>&1; then
-    init="0" # it's a flag. init with 0
-    eval "${varname}=0"
+  __b3bp_tmp_varname="__b3bp_tmp_has_arg_${__b3bp_tmp_opt}"
+  if ! echo "${__b3bp_tmp_line}" |egrep '\[.*\]' >/dev/null 2>&1; then
+    __b3bp_tmp_init="0" # it's a flag. init with 0
+    eval "${__b3bp_tmp_varname}=0"
   else
-    opt="${opt}:" # add : if opt has arg
-    init=""  # it has an arg. init with ""
-    eval "${varname}=1"
+    __b3bp_tmp_opt="${__b3bp_tmp_opt}:" # add : if opt has arg
+    __b3bp_tmp_init=""  # it has an arg. init with ""
+    eval "${__b3bp_tmp_varname}=1"
   fi
-  opts="${opts:-}${opt}"
+  __b3bp_tmp_opts="${__b3bp_tmp_opts:-}${__b3bp_tmp_opt}"
 
-  varname="arg_${opt:0:1}"
-  if ! echo "${line}" |egrep '\. Default=' >/dev/null 2>&1; then
-    eval "${varname}=\"${init}\""
+  __b3bp_tmp_varname="arg_${__b3bp_tmp_opt:0:1}"
+  if ! echo "${__b3bp_tmp_line}" |egrep '\. Default=' >/dev/null 2>&1; then
+    eval "${__b3bp_tmp_varname}=\"${__b3bp_tmp_init}\""
   else
-    match="$(echo "${line}" |sed 's#^.*Default=\(\)#\1#g')"
-    eval "${varname}=\"${match}\""
+    __b3bp_tmp_match="$(echo "${__b3bp_tmp_line}" |sed 's#^.*Default=\(\)#\1#g')"
+    eval "${__b3bp_tmp_varname}=\"${__b3bp_tmp_match}\""
   fi
 done <<< "${__usage}"
 
 # Allow long options like --this
-opts="${opts}-:"
+__b3bp_tmp_opts="${__b3bp_tmp_opts}-:"
 
 # Reset in case getopts has been used previously in the shell.
 OPTIND=1
@@ -149,46 +149,56 @@ OPTIND=1
 set +o nounset # unexpected arguments will cause unbound variables
                # to be dereferenced
 # Overwrite $arg_<flag> defaults with the actual CLI options
-while getopts "${opts}" opt; do
-  [ "${opt}" = "?" ] && help "Invalid use of script: ${@} "
+while getopts "${__b3bp_tmp_opts}" __b3bp_tmp_opt; do
+  [ "${__b3bp_tmp_opt}" = "?" ] && help "Invalid use of script: ${@} "
 
-  if [ "${opt}" = "-" ]; then
+  if [ "${__b3bp_tmp_opt}" = "-" ]; then
     # OPTARG is long-option-name or long-option=value
     if [[ "${OPTARG}" =~ .*=.* ]]; then
       # --key=value format
-      long=${OPTARG/=*/}
-      long_mangled="$(sed 's#-#_#g' <<< $long)"
+      __b3bp_tmp_long_opt=${OPTARG/=*/}
+      __b3bp_tmp_long_opt_mangled="$(sed 's#-#_#g' <<< $__b3bp_tmp_long_opt)"
       # Set opt to the short option corresponding to the long option
-      eval "opt=\"\${short_opt_${long_mangled}}\""
+      eval "__b3bp_tmp_opt=\"\${__b3bp_tmp_short_opt_${__b3bp_tmp_long_opt_mangled}}\""
       OPTARG=${OPTARG#*=}
     else
       # --key value format
       # Map long name to short version of option
-      long_mangled="$(sed 's#-#_#g' <<< $OPTARG)"
-      eval "opt=\"\${short_opt_${long_mangled}}\""
+      __b3bp_tmp_long_opt_mangled="$(sed 's#-#_#g' <<< $OPTARG)"
+      eval "__b3bp_tmp_opt=\"\${__b3bp_tmp_short_opt_${__b3bp_tmp_long_opt_mangled}}\""
       # Only assign OPTARG if option takes an argument
-      eval "OPTARG=\"\${@:OPTIND:\${has_arg_${opt}}}\""
+      eval "OPTARG=\"\${@:OPTIND:\${__b3bp_tmp_has_arg_${__b3bp_tmp_opt}}}\""
       # shift over the argument if argument is expected
-      ((OPTIND+=has_arg_${opt}))
+      ((OPTIND+=__b3bp_tmp_has_arg_${__b3bp_tmp_opt}))
     fi
     # we have set opt/OPTARG to the short value and the argument as OPTARG if it exists
   fi
-  varname="arg_${opt:0:1}"
-  default="${!varname}"
+  __b3bp_tmp_varname="arg_${__b3bp_tmp_opt:0:1}"
+  __b3bp_tmp_default="${!__b3bp_tmp_varname}"
 
-  value="${OPTARG}"
-  if [ -z "${OPTARG}" ] && [ "${default}" = "0" ]; then
-    value="1"
+  __b3bp_tmp_value="${OPTARG}"
+  if [ -z "${OPTARG}" ] && [ "${__b3bp_tmp_default}" = "0" ]; then
+    __b3bp_tmp_value="1"
   fi
 
-  eval "${varname}=\"${value}\""
-  debug "cli arg ${varname} = ($default) -> ${!varname}"
+  eval "${__b3bp_tmp_varname}=\"${__b3bp_tmp_value}\""
+  debug "cli arg ${__b3bp_tmp_varname} = ($__b3bp_tmp_default) -> ${!__b3bp_tmp_varname}"
 done
 set -o nounset # no more unbound variable references expected
 
 shift $((OPTIND-1))
 
 [ "${1:-}" = "--" ] && shift
+
+
+### Cleanup Environment variables
+##############################################################################
+
+for __tmp_varname in ${!__b3bp_tmp_*}; do
+  eval "unset ${__tmp_varname}"
+done
+
+unset __tmp_varname
 
 
 ### Command-line argument switches (like -d for debugmode, -h for showing helppage)


### PR DESCRIPTION
all internally used variable names (e.g. the ones used while parsing
__usage and running the getopts loop) start with '__b3bp_tmp'. This
makes it easy to unset them all after the work is done.