### PR TITLE
bugfix for magic vars __file and __dir

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -26,9 +26,13 @@ set -o pipefail
 # Turn on traces, useful while debugging but commented out by default
 # set -o xtrace
 
+if [ "${BASH_SOURCE[0]}" != "${0}" ]; then
+  __b3bp_tmp_source_idx=1
+fi
+
 # Set magic variables for current file, directory, os, etc.
-__dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-__file="${__dir}/$(basename "${BASH_SOURCE[0]}")"
+__dir="$(cd "$(dirname "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")" && pwd)"
+__file="${__dir}/$(basename "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")"
 __base="$(basename ${__file} .sh)"
 
 # Define the environment variables (and their defaults) that this script depends on


### PR DESCRIPTION
as mentioned in the FAQ it is a supported possibility to actually source main.sh (after tailoring it to specific needs). yet the magic variables __file and __dir are not set properly in this case. this fix will have these variables set properly either way (executed or sourced).
