### PR TITLE
mention the used license in each script header

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -8,8 +8,12 @@
 #  LOG_LEVEL=7 ./main.sh -f /tmp/x -d (change this for your script)
 #
 # Based on a template by BASH3 Boilerplate v2.1.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 # Exit on error. Append || true if you expect an error.
 set -o errexit

--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -19,8 +19,12 @@
 #  ini_val.sh data.ini connection.host 127.0.0.1
 #
 # Based on a template by BASH3 Boilerplate v2.1.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 function ini_val() {
   local file="${1:-}"

--- a/src/megamount.sh
+++ b/src/megamount.sh
@@ -21,8 +21,12 @@
 #  megamount.sh smb://janedoe:abc123@192.168.0.1/documents /mnt/documents
 #
 # Based on a template by BASH3 Boilerplate v2.1.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 __dir=$(cd `dirname "${BASH_SOURCE[0]}"` && pwd)
 source "${__dir}/parse_url.sh"

--- a/src/parse_url.sh
+++ b/src/parse_url.sh
@@ -19,8 +19,12 @@
 #  parse_url.sh 'http://johndoe:abc123@example.com:8080/index.html'
 #
 # Based on a template by BASH3 Boilerplate v2.1.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 function parse_url() {
   local parse="${1}"

--- a/src/templater.sh
+++ b/src/templater.sh
@@ -17,8 +17,12 @@
 #  ALLOW_REMAINDERS=1 templater.sh input.cfg output.cfg
 #
 # Based on a template by BASH3 Boilerplate v2.1.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 function templater() {
   ALLOW_REMAINDERS="${ALLOW_REMAINDERS:-0}"

--- a/test/acceptance.sh
+++ b/test/acceptance.sh
@@ -10,8 +10,12 @@
 #  ./deploy.sh
 #
 # Based on a template by BASH3 Boilerplate v2.0.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 # Exit on error. Append || true if you expect an error.
 set -o errexit

--- a/website/_bin/deploy.sh
+++ b/website/_bin/deploy.sh
@@ -11,8 +11,12 @@
 #  ./deploy.sh
 #
 # Based on a template by BASH3 Boilerplate v2.0.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 # Exit on error. Append || true if you expect an error.
 set -o errexit

--- a/website/_bin/inject.sh
+++ b/website/_bin/inject.sh
@@ -9,8 +9,12 @@
 #  ./inject.sh
 #
 # Based on a template by BASH3 Boilerplate v2.0.0
-# Copyright (c) 2013 Kevin van Zonneveld and contributors
 # http://bash3boilerplate.sh/#authors
+#
+# The MIT License (MIT)
+# Copyright (c) 2013 Kevin van Zonneveld and contributors
+# You are not obligated to bundle the LICENSE file with your b3bp projects as long
+# as you leave these references intact in the header comments of your source files.
 
 # Exit on error. Append || true if you expect an error.
 set -o errexit


### PR DESCRIPTION
turns out that the README.md explains that "... licensed under MIT ...
the LICENSE does not have to be bundled as long as ..." but the scripts
themselfs don't mention any license.

fixed that by adding a one line mention of the used license and the two
lines explaining that the header comments have to stay intact.