### PR TITLE
removed all usage of eval, proper usage of unset

### DIFF
--- a/test/fixture/main-usage-defaults.stdio
+++ b/test/fixture/main-usage-defaults.stdio
@@ -1,7 +1,7 @@
 ACCPTST:STDIO_REPLACE_DATETIMES
 {datetime} UTC [32m[     info][0m arg_1: 0
 {datetime} UTC [32m[     info][0m arg_2: 0
-{datetime} UTC [32m[     info][0m arg_3: THREE
-{datetime} UTC [32m[     info][0m arg_4: FOUR
+{datetime} UTC [32m[     info][0m arg_3: 'THREE'
+{datetime} UTC [32m[     info][0m arg_4: "FOUR"
 {datetime} UTC [32m[     info][0m arg_5: OOOPS
 {datetime} UTC [32m[     info][0m arg_6: 

--- a/test/scenario/main-usage-defaults/run.sh
+++ b/test/scenario/main-usage-defaults/run.sh
@@ -16,12 +16,12 @@ read -r -d '' __usage <<-'EOF' || true # exits non-zero when EOF encountered
                    More description.
   -2 --two         Do two things.
                    More description. Default="TWO"
-  -3 --three [arg] Do three things. Default="THREE"
+  -3 --three [arg] Do three things. Default="'THREE'"
                    More description.
   -4 --four  [arg] Do four things.
-                   More description. Default="FOUR"
+                   More description. Default='"FOUR"'
   -5 --five  [arg] Do five things. Default="FIVE"
-                   More description. Default="OOOPS"
+                   More description. Default='OOOPS'
   -6 --six   [arg] Do six things.
                    More description.
 EOF


### PR DESCRIPTION
replaced all `eval` with `printf -v` for security reasons.

the behaviour of unset without -v/-f is actually undefined so make the
intent clear.