### PR TITLE
Fix typos in megamount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released: TBA.
 [Diff](https://github.com/kvz/bash3boilerplate/compare/v2.3.0...master).
 
 - [ ] Upgrade to `lanyon@0.0.55`
+- [x] Fix typos in megamount (thanks @gsaponaro)
 
 ## v2.3.0
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [@skanga](https://github.com/skanga) (feedback)
 - [galaktos](https://www.reddit.com/user/galaktos) (feedback)
 - [@moviuro](https://github.com/moviuro) (feedback)
+- [Giovanni Saponaro](https://github.com/gsaponaro) (feedback)
 
 ## License
 

--- a/src/megamount.sh
+++ b/src/megamount.sh
@@ -4,8 +4,8 @@
 # This file:
 #
 #  - Takes a URL (smb, nfs, afs) and tries to mount it at a given target directory
-#  - Forceully unmounts any active mount at the target directory first
-#  - Displays the mounts contents for verification
+#  - Forcefully unmounts any active mount at the target directory first
+#  - Displays the mount's contents for verification
 #
 # Depends on:
 #


### PR DESCRIPTION
Hi, thanks for the useful resource!
This PR fixes two typos in the `megamount.sh` manual (in the comments). I did not change the actual code. I also added my name, not being sure if this small change warrants that -- let me know if I should change anything.

- [x] Added an item in [CHANGELOG.md](https://github.com/kvz/bash3boilerplate/blob/master/CHANGELOG.md) with attribution?
- [x] Added your name to the [README.md](https://github.com/kvz/bash3boilerplate/blob/master/README.md#authors)
- [ ] Linted your code? (`make test` should do the trick)


