### PR TITLE
Enable color in screen or tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Released: TBA.
 
 - [ ] Upgrade to `lanyon@0.0.55`
 - [x] Fix typos in megamount (thanks @gsaponaro)
+- [x] Enable color in screen or tmux (@gmasse)
 
 ## v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Released: TBA.
 - [ ] Upgrade to `lanyon@0.0.55`
 - [x] Fix typos in megamount (thanks @gsaponaro)
 - [x] Enable color in screen or tmux (#92, @gmasse)
-- [x] Change `egrep` to `grep -E` in acceptance test script to comply with ShellCheck (#92, @gmasse)
+- [x] Change `egrep` to `grep -E` in test and lib scripts to comply with ShellCheck (#92, @gmasse)
 
 ## v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Released: TBA.
 - [x] Fix typos in megamount (thanks @gsaponaro)
 - [x] Enable color in screen or tmux (#92, @gmasse)
 - [x] Change `egrep` to `grep -E` in test and lib scripts to comply with ShellCheck (#92, @gmasse)
+- [x] Fix typo in FAQ (#92, @gmasse)
 
 ## v2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Released: TBA.
 
 - [ ] Upgrade to `lanyon@0.0.55`
 - [x] Fix typos in megamount (thanks @gsaponaro)
-- [x] Enable color in screen or tmux (@gmasse)
+- [x] Enable color in screen or tmux (#92, @gmasse)
+- [x] Change `egrep` to `grep -E` in acceptance test script to comply with ShellCheck (#92, @gmasse)
 
 ## v2.3.0
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -55,7 +55,7 @@ source main.sh
 1. Copy the line from the `main.sh` [read block](https://github.com/kvz/bash3boilerplate/blob/v2.1.0/main.sh#L109-L115) that most resembles the desired behavior and paste the line into the same block.
 1. Edit the single-character (e.g., `-d`) and, if present, the multi-character (e.g., `--debug`) versions of the flag in the copied line.
 1. Omit the `[arg]` text in the copied line, if the desired flag takes no arguments.
-1. Omit or edit the text after `Default:` to set or not set default values, respectively.
+1. Omit or edit the text after `Default=` to set or not set default values, respectively.
 1. Omit the `Required.` text, if the flag is optional.
 
 ## How do I access the value of a command-line argument?

--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [galaktos](https://www.reddit.com/user/galaktos) (feedback)
 - [@moviuro](https://github.com/moviuro) (feedback)
 - [Giovanni Saponaro](https://github.com/gsaponaro) (feedback)
+- [Germain Masse](https://github.com/gmasse)
 
 ## License
 

--- a/main.sh
+++ b/main.sh
@@ -83,7 +83,7 @@ function __b3bp_log () {
   local color="${!colorvar:-${color_error}}"
   local color_reset="\x1b[0m"
 
-  if [[ "${NO_COLOR:-}" = "true" ]] || [[ "${TERM:-}" != "xterm"* ]] || [[ ! -t 2 ]]; then
+  if [[ "${NO_COLOR:-}" = "true" ]] || ( [[ "${TERM:-}" != "xterm"* ]] && [[ "${TERM:-}" != "screen"* ]] ) || [[ ! -t 2 ]]; then
     if [[ "${NO_COLOR:-}" != "false" ]]; then
       # Don't use colors on pipes or non-recognized terminals
       color=""; color_reset=""

--- a/src/templater.sh
+++ b/src/templater.sh
@@ -40,7 +40,7 @@ function templater() {
   fi
 
   cp -f "${templateSrc}" "${templateDst}"
-  for var in $(env |awk -F= '{print $1}' |egrep '^[A-Z0-9_]+$'); do
+  for var in $(env |awk -F= '{print $1}' |grep -E '^[A-Z0-9_]+$'); do
     sed -i.bak -e "s#\${${var}}#${!var}#g" "${templateDst}"
     # this .bak dance is done for BSD/GNU portability: http://stackoverflow.com/a/22084103/151666
     rm -f "${templateDst}.bak"

--- a/test/acceptance.sh
+++ b/test/acceptance.sh
@@ -63,7 +63,7 @@ __node="$(which node)"
 __arch="amd64"
 
 # explicitly setting NO_COLOR to false will make b3bp ignore TERM
-# not being "xterm*" and STDERR not being connected to a terminal
+# not being "xterm*" or "screen*" and STDERR not being connected to a terminal
 # it's the opposite of NO_COLOR="true" - it forces color, no matter what
 export NO_COLOR="false"
 

--- a/test/acceptance.sh
+++ b/test/acceptance.sh
@@ -148,7 +148,7 @@ while IFS=$'\n' read -r scenario; do
         "${curFile}"
       fi
       if grep -q 'ACCPTST:STDIO_REPLACE_REMOTE_EXEC' "${curFile}"; then
-        egrep -v 'remote-exec\): [ a-zA-Z]' "${curFile}" > "${__sysTmpDir}/accptst-filtered.txt"
+        grep -Ev 'remote-exec\): [ a-zA-Z]' "${curFile}" > "${__sysTmpDir}/accptst-filtered.txt"
         mv "${__sysTmpDir}/accptst-filtered.txt" "${curFile}"
       fi
     done


### PR DESCRIPTION
As screen (and tmux obviously) is now compiled with 256 colors most of the time, I have added the detection of these TERMs for auto-color feature

- [x] Added an item in [CHANGELOG.md](https://github.com/kvz/bash3boilerplate/blob/master/CHANGELOG.md) with attribution?
- [x] Added your name to the [README.md](https://github.com/kvz/bash3boilerplate/blob/master/README.md#authors)
- [x] Linted your code? (`make test` should do the trick)