### PR TITLE
templater.sh: Update Regexp to not match ${_} for replacement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,10 @@ Released: TBA.
 
 - [ ] Upgrade to `lanyon@0.0.55`
 - [x] Fix typos in megamount (thanks @gsaponaro)
-- [x] Enable color in screen or tmux (#92, @gmasse)
+- [x] Enable color in screen or tmux (#92, @gmasse)
 - [x] Change `egrep` to `grep -E` in test and lib scripts to comply with ShellCheck (#92, @gmasse)
 - [x] Fix typo in FAQ (#92, @gmasse)
+- [x] Fix Travis CI failure on src/templater.sh (@gmasse)
 
 ## v2.3.0
 

--- a/src/templater.sh
+++ b/src/templater.sh
@@ -40,7 +40,7 @@ function templater() {
   fi
 
   cp -f "${templateSrc}" "${templateDst}"
-  for var in $(env |awk -F= '{print $1}' |grep -E '^[A-Z0-9_]+$'); do
+  for var in $(env |awk -F= '{print $1}' |grep -E '^(_[A-Z0-9_]+|[A-Z0-9][A-Z0-9_]*)$'); do
     sed -i.bak -e "s#\${${var}}#${!var}#g" "${templateDst}"
     # this .bak dance is done for BSD/GNU portability: http://stackoverflow.com/a/22084103/151666
     rm -f "${templateDst}.bak"


### PR DESCRIPTION
This fix should permit Travis CI to pass

- [x] Added an item in [CHANGELOG.md](https://github.com/kvz/bash3boilerplate/blob/master/CHANGELOG.md) with attribution?
- [x] Added your name to the [README.md](https://github.com/kvz/bash3boilerplate/blob/master/README.md#authors)
- [x] Linted your code? (`make test` should do the trick)