### PR TITLE
Allow counting how many times an argument is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released: TBA.
 [Diff](https://github.com/kvz/bash3boilerplate/compare/v2.3.0...master).
 
 - [ ] Upgrade to `lanyon@0.0.55`
+- [ ] Allow counting how many times an argument is used
 - [x] Fix typos in megamount (thanks @gsaponaro)
 - [x] Enable color in screen or tmux (#92, @gmasse)
 - [x] Change `egrep` to `grep -E` in test and lib scripts to comply with ShellCheck (#92, @gmasse)

--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [@moviuro](https://github.com/moviuro) (feedback)
 - [Giovanni Saponaro](https://github.com/gsaponaro) (feedback)
 - [Germain Masse](https://github.com/gmasse)
+- [A. G. Madi](https://github.com/warpengineer)
 
 ## License
 

--- a/main.sh
+++ b/main.sh
@@ -257,8 +257,8 @@ if [[ "${__b3bp_tmp_opts:-}" ]]; then
     __b3bp_tmp_default="${!__b3bp_tmp_varname}"
 
     __b3bp_tmp_value="${OPTARG}"
-    if [[ -z "${OPTARG}" ]] && [[ "${__b3bp_tmp_default}" = "0" ]]; then
-      __b3bp_tmp_value="1"
+    if [[ -z "${OPTARG}" ]]; then
+      __b3bp_tmp_value=$((__b3bp_tmp_default + 1))
     fi
 
     printf -v "${__b3bp_tmp_varname}" '%s' "${__b3bp_tmp_value}"


### PR DESCRIPTION
An example of use would be the passing in of multiple -v options in some utilities to increase verbosity.
