### PR TITLE
Add magic variable that stores the full command line invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Released: TBA.
 - [x] Change `egrep` to `grep -E` in test and lib scripts to comply with ShellCheck (#92, @gmasse)
 - [x] Fix typo in FAQ (#92, @gmasse)
 - [x] Fix Travis CI failure on src/templater.sh (@gmasse)
+- [x] Add magic variable which contains full command invocation
 
 ## v2.3.0
 

--- a/main.sh
+++ b/main.sh
@@ -47,7 +47,7 @@ fi
 __dir="$(cd "$(dirname "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")" && pwd)"
 __file="${__dir}/$(basename "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")"
 __base="$(basename "${__file}" .sh)"
-
+__invocation="$(printf %q "${__file}")$((($#)) && printf ' %q' "$@")"
 
 # Define the environment variables (and their defaults) that this script depends on
 LOG_LEVEL="${LOG_LEVEL:-6}" # 7 = debug -> 0 = emergency


### PR DESCRIPTION
Add a magic variable to provide the full invocation of the script. Intended for logging purposes.
