### PR TITLE
Add || true to fix __invocation with no arguments

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -47,7 +47,7 @@ fi
 __dir="$(cd "$(dirname "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")" && pwd)"
 __file="${__dir}/$(basename "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")"
 __base="$(basename "${__file}" .sh)"
-__invocation="$(printf %q "${__file}")$((($#)) && printf ' %q' "$@")"
+__invocation="$(printf %q "${__file}")$((($#)) && printf ' %q' "$@" || true)"
 
 # Define the environment variables (and their defaults) that this script depends on
 LOG_LEVEL="${LOG_LEVEL:-6}" # 7 = debug -> 0 = emergency


### PR DESCRIPTION
Fixes #101 which should read "example.sh no longer prints out help when run with no arguments"