### PR TITLE
Disable history substitution

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -23,6 +23,8 @@ set -o errtrace
 set -o nounset
 # Catch the error in case mysqldump fails (but gzip succeeds) in `mysqldump |gzip`
 set -o pipefail
+# Disable history substitution, will break things like echo `"Hello World!"`
+set +H
 # Turn on traces, useful while debugging but commented out by default
 # set -o xtrace
 


### PR DESCRIPTION
History substitution can mess up non interactive mode in some pretty unexpected ways, as can be seen here https://serverfault.com/q/208265/20186

I think that a best practice might be to just kill it off when scripting.

Thanks for contributing to b3bp! As part of your PR, have you:

- [ ] Added an item in [CHANGELOG.md](https://github.com/kvz/bash3boilerplate/blob/master/CHANGELOG.md) with attribution?
- [ ] Added your name to the [README.md](https://github.com/kvz/bash3boilerplate/blob/master/README.md#authors)
- [ ] Linted your code? (`make test` should do the trick)

If so, great! Feel free to replace this message with a description of your work and hit submit!
