### PR TITLE
Travis update: 🍏+🐧 use latest shellcheck binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,44 +1,65 @@
 matrix:
   include:
-  - os: linux
-    sudo: false
-    language: node_js
-    node_js: 10
-  - os: osx
-    language: node_js
-    node_js: 10
+    - os: linux
+      sudo: false
+      language: node_js
+      node_js: 10
+    - os: osx
+      language: node_js
+      node_js: 10
 
 env:
   global:
-  - SCROLEX_MODE=passthru
-  - secure: BeM6mpPEATdeFcAr/222QBZ9vRkZtU2WOi9QQy3mxsuDbWfM8RxYESIEJLipyhW9kXGoe6HGMqm4Kz9B/c4jrzeSXPpKnW7mIfnyqN+hhq1ctW9qPSqodu+fYNhdDxXh5wylml7hnIJzU70vFGrFknZRE2FYk5XvyHg2ImIKDJw=
-  - secure: RJ5UpdXms9QkraylZ11OBfmcRrmKnb254Yj0yCDAvZmg+n+3jSTwMgGvPY8Ih8X/R1JeW3VTtFDkJXXPnjjfpNg1M91u4CAEUOMPciCudYcoF6GKb8psnOzneTTX5M7zuJSzknGdpv/foldxiPYxiY5Hn5bfjmikhAEl+QX/R0Y=
-  - secure: BXf2buPt/DA09M5ZUdp/LpOWtUuz1mfCBopLyxvHv3Sl3ln+Az57wWsM2+Re+77lUOgihR2f6lXYfNUmQuSUo157rZPunQCqM/DJhK69KhREEB6SJDaJF3FVlnGla+Cwwb1IQUtMopqX9pBYD7w/zyWQFJCi20O57JEVIdfZZS8=
-  - secure: AaDI3OLTcwau2tu9jTtR0eHpylSUudYua9aKH3C540Lm2scQhQcT4IbMa6KXgrY+1UchapS9gUuClH8QwgJo61tJjtOqvmCgZ2EkmZg68pzw/25zwv7LSzYASbZvKahulV/giZdxFLGOpPhNhKbG70/owYXjKFENi5LoZKc8Y+c=
+    - SCROLEX_MODE=passthru
+    - secure: BeM6mpPEATdeFcAr/222QBZ9vRkZtU2WOi9QQy3mxsuDbWfM8RxYESIEJLipyhW9kXGoe6HGMqm4Kz9B/c4jrzeSXPpKnW7mIfnyqN+hhq1ctW9qPSqodu+fYNhdDxXh5wylml7hnIJzU70vFGrFknZRE2FYk5XvyHg2ImIKDJw=
+    - secure: RJ5UpdXms9QkraylZ11OBfmcRrmKnb254Yj0yCDAvZmg+n+3jSTwMgGvPY8Ih8X/R1JeW3VTtFDkJXXPnjjfpNg1M91u4CAEUOMPciCudYcoF6GKb8psnOzneTTX5M7zuJSzknGdpv/foldxiPYxiY5Hn5bfjmikhAEl+QX/R0Y=
+    - secure: BXf2buPt/DA09M5ZUdp/LpOWtUuz1mfCBopLyxvHv3Sl3ln+Az57wWsM2+Re+77lUOgihR2f6lXYfNUmQuSUo157rZPunQCqM/DJhK69KhREEB6SJDaJF3FVlnGla+Cwwb1IQUtMopqX9pBYD7w/zyWQFJCi20O57JEVIdfZZS8=
+    - secure: AaDI3OLTcwau2tu9jTtR0eHpylSUudYua9aKH3C540Lm2scQhQcT4IbMa6KXgrY+1UchapS9gUuClH8QwgJo61tJjtOqvmCgZ2EkmZg68pzw/25zwv7LSzYASbZvKahulV/giZdxFLGOpPhNhKbG70/owYXjKFENi5LoZKc8Y+c=
 
 addons:
   apt:
     update: true
+    packages:
+      - xz-utils
   homebrew:
     update: true
     packages:
       - coreutils
       - gnu-sed
 
+git:
+  depth: 3
+
 before_install:
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install --allow-unauthenticated -y cabal-install; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then cabal update; fi
-- if [ "$TRAVIS_OS_NAME" = "linux" ]; then cabal v1-install ShellCheck; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then which bundle || gem install bundler; fi
-- bash --version
-- awk --version
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then command -v bundle || gem install bundler; fi
+  - |
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
+      sctmp="$( mktemp -d)" && pushd "${sctmp}" > /dev/null || return
+      scversion="latest" # or "v0.4.7", or "stable"
+      curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz"
+      curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz.sha512sum"
+      if sha512sum -c --quiet "shellcheck-${scversion?}.linux.x86_64.tar.xz.sha512sum"; then
+        tar -x --xz -f "shellcheck-${scversion?}.linux.x86_64.tar.xz"
+        sudo install -v -m0755 "${sctmp}/shellcheck-${scversion}/shellcheck" "$(command -v shellcheck)"
+        grep 'binary was compiled' "${sctmp}/shellcheck-${scversion}/README.txt"
+      fi
+      popd > /dev/null || return
+    fi
+
+before_script:
+  - bash --version
+  - awk --version
+  - shellcheck --version
+
 before_cache:
-- rm -f ./node_modules/.bin/which
-# cache:
-#   apt: true
-#   directories:
-#   - .lanyon
+  - rm -f ./node_modules/.bin/which
+  # cache:
+  #   apt: true
+  #   directories:
+  #   - .lanyon
+
 script: test/acceptance.sh
+
 deploy:
   skip_cleanup: true
   provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,65 +28,48 @@ addons:
       - gnu-sed
       - gnu-tar
       - grep
+      - make
       - gawk
       - findutils
-      # - gnu-indent
-      # - gnutls
+      - gnu-which
+      - gnu-time
 
 git:
   depth: 3
 
 before_install:
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then type -P bundle || gem install bundler; fi
   - |
     if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       if type brew &>/dev/null; then
-        HOMEBREW_PREFIX=$(brew --prefix)
-        # gnubin;
+        HOMEBREW_PREFIX=$(brew --prefix)  # add gnubin commands to PATH
         for d in ${HOMEBREW_PREFIX}/opt/*/libexec/gnubin; do export PATH=$d:$PATH; done
-        # gnuman
-        # for d in ${HOMEBREW_PREFIX}/opt/*/libexec/gnuman; do export MANPATH=$d:$MANPATH; done
       fi
     fi
   - |
-    echo ######################################
-    echo "Testing GNU binaries"
-    sha512sum --version || true
-    tar --version|| true
-    install --version || true
-    grep --version || true
-    sed --version || true
-    find --version || true
-    date --version || true
-    make --version || true
-    echo ######################################
-    echo
-  - |
-    sc_version="latest" # or "v0.7.0", or "stable"
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then sc_arch="linux";  fi
-    if [ "$TRAVIS_OS_NAME" = "osx"   ]; then sc_arch="darwin"; fi
-    if type shellcheck &>/dev/null; then
-      sc_bin="$(type -P shellcheck)"
-    else
-      sc_bin=/usr/bin/shellcheck
-    fi
+    sc_version="latest"                   # or "v0.7.0", or "stable"
+    sc_bin="/usr/local/bin/shellcheck"    # a default binary target
+    if type shellcheck &>/dev/null; then sc_bin="$(type -P shellcheck)"; fi
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then sc_os="linux";  fi
+    if [ "$TRAVIS_OS_NAME" = "osx"   ]; then sc_os="darwin"; fi
+    sc_tmp="$(mktemp -d || return)"
 
-    sc_tmp="$(mktemp -d)" && pushd "${sc_tmp}" > /dev/null || return
-    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz"
-    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"
-    if sha512sum -c --quiet "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"; then
-      tar -x --xz -f "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz"
+    pushd "${sc_tmp}" &>/dev/null || return
+    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_os}.x86_64.tar.xz"
+    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_os}.x86_64.tar.xz.sha512sum"
+    if sha512sum -c --quiet "shellcheck-${sc_version?}.${sc_os}.x86_64.tar.xz.sha512sum"; then
+      tar -x --xz -f "shellcheck-${sc_version?}.${sc_os}.x86_64.tar.xz"
       sudo install -v -m0755 "${sc_tmp}/shellcheck-${sc_version}/shellcheck" "$sc_bin"
-      echo ######################################
       grep 'binary was compiled' "${sc_tmp}/shellcheck-${sc_version}/README.txt"
-      "$sc_bin" --version || shellcheck --version  || true
     fi
-    popd > /dev/null || return
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then type -P bundle || gem install bundler; fi
-
+    popd &>/dev/null || return
 
 before_script:
-  - bash --version
-  - awk --version
+  - bash --version || true
+  - awk  --version || true
+  - sed  --version || true
+  - make --version || true
+  - shellcheck --version || true
 
 before_cache:
   - rm -f ./node_modules/.bin/which

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,30 +26,44 @@ addons:
     packages:
       - coreutils
       - gnu-sed
+      - gnu-tar
+      - grep
+      - gawk
+      - findutils
+      # - gnu-indent
+      # - gnutls
 
 git:
   depth: 3
 
 before_install:
-  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then command -v bundle || gem install bundler; fi
   - |
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then
-      sctmp="$( mktemp -d)" && pushd "${sctmp}" > /dev/null || return
-      scversion="latest" # or "v0.4.7", or "stable"
-      curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz"
-      curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${scversion?}.linux.x86_64.tar.xz.sha512sum"
-      if sha512sum -c --quiet "shellcheck-${scversion?}.linux.x86_64.tar.xz.sha512sum"; then
-        tar -x --xz -f "shellcheck-${scversion?}.linux.x86_64.tar.xz"
-        sudo install -v -m0755 "${sctmp}/shellcheck-${scversion}/shellcheck" "$(command -v shellcheck)"
-        grep 'binary was compiled' "${sctmp}/shellcheck-${scversion}/README.txt"
-      fi
-      popd > /dev/null || return
+    sc_version="latest" # or "v0.7.0", or "stable"
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then sc_arch="linux";  install_bin="$(type -P install)";  fi
+    if [ "$TRAVIS_OS_NAME" = "osx"   ]; then sc_arch="darwin"; install_bin="$(type -P ginstall)"; fi
+    if type -P shellcheck > /dev/null; then
+      sc_bin="$(type -P shellcheck)"
+    else
+      sc_bin=/usr/bin/shellcheck
     fi
+
+    sc_tmp="$(mktemp -d)" && pushd "${sc_tmp}" > /dev/null || return
+    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz"
+    curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"
+    if sha512sum -c --quiet "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"; then
+      tar -x --xz -f "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz"
+      sudo "$install_bin" -v -m0755 "${sc_tmp}/shellcheck-${sc_version}/shellcheck" "$sc_bin"
+      echo ######################################
+      grep 'binary was compiled' "${sc_tmp}/shellcheck-${sc_version}/README.txt"
+      "$sc_bin" --version || shellcheck --version
+    fi
+    popd > /dev/null || return
+  - if [ "$TRAVIS_OS_NAME" = "osx" ]; then type -P bundle || gem install bundler; fi
+
 
 before_script:
   - bash --version
   - awk --version
-  - shellcheck --version
 
 before_cache:
   - rm -f ./node_modules/.bin/which

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,33 @@ git:
 
 before_install:
   - |
+    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
+      if type brew &>/dev/null; then
+        HOMEBREW_PREFIX=$(brew --prefix)
+        # gnubin;
+        for d in ${HOMEBREW_PREFIX}/opt/*/libexec/gnubin; do export PATH=$d:$PATH; done
+        # gnuman
+        # for d in ${HOMEBREW_PREFIX}/opt/*/libexec/gnuman; do export MANPATH=$d:$MANPATH; done
+      fi
+    fi
+  - |
+    echo ######################################
+    echo "Testing GNU binaries"
+    sha512sum --version || true
+    tar --version|| true
+    install --version || true
+    grep --version || true
+    sed --version || true
+    find --version || true
+    date --version || true
+    make --version || true
+    echo ######################################
+    echo
+  - |
     sc_version="latest" # or "v0.7.0", or "stable"
-    if [ "$TRAVIS_OS_NAME" = "linux" ]; then sc_arch="linux";  install_bin="$(type -P install)";  fi
-    if [ "$TRAVIS_OS_NAME" = "osx"   ]; then sc_arch="darwin"; install_bin="$(type -P ginstall)"; fi
-    if type -P shellcheck > /dev/null; then
+    if [ "$TRAVIS_OS_NAME" = "linux" ]; then sc_arch="linux";  fi
+    if [ "$TRAVIS_OS_NAME" = "osx"   ]; then sc_arch="darwin"; fi
+    if type shellcheck &>/dev/null; then
       sc_bin="$(type -P shellcheck)"
     else
       sc_bin=/usr/bin/shellcheck
@@ -52,10 +75,10 @@ before_install:
     curl -k -sSLO "https://storage.googleapis.com/shellcheck/shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"
     if sha512sum -c --quiet "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz.sha512sum"; then
       tar -x --xz -f "shellcheck-${sc_version?}.${sc_arch}.x86_64.tar.xz"
-      sudo "$install_bin" -v -m0755 "${sc_tmp}/shellcheck-${sc_version}/shellcheck" "$sc_bin"
+      sudo install -v -m0755 "${sc_tmp}/shellcheck-${sc_version}/shellcheck" "$sc_bin"
       echo ######################################
       grep 'binary was compiled' "${sc_tmp}/shellcheck-${sc_version}/README.txt"
-      "$sc_bin" --version || shellcheck --version
+      "$sc_bin" --version || shellcheck --version  || true
     fi
     popd > /dev/null || return
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then type -P bundle || gem install bundler; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
   - os: osx
     language: node_js
     node_js: 10
+
 env:
   global:
   - SCROLEX_MODE=passthru
@@ -14,17 +15,20 @@ env:
   - secure: RJ5UpdXms9QkraylZ11OBfmcRrmKnb254Yj0yCDAvZmg+n+3jSTwMgGvPY8Ih8X/R1JeW3VTtFDkJXXPnjjfpNg1M91u4CAEUOMPciCudYcoF6GKb8psnOzneTTX5M7zuJSzknGdpv/foldxiPYxiY5Hn5bfjmikhAEl+QX/R0Y=
   - secure: BXf2buPt/DA09M5ZUdp/LpOWtUuz1mfCBopLyxvHv3Sl3ln+Az57wWsM2+Re+77lUOgihR2f6lXYfNUmQuSUo157rZPunQCqM/DJhK69KhREEB6SJDaJF3FVlnGla+Cwwb1IQUtMopqX9pBYD7w/zyWQFJCi20O57JEVIdfZZS8=
   - secure: AaDI3OLTcwau2tu9jTtR0eHpylSUudYua9aKH3C540Lm2scQhQcT4IbMa6KXgrY+1UchapS9gUuClH8QwgJo61tJjtOqvmCgZ2EkmZg68pzw/25zwv7LSzYASbZvKahulV/giZdxFLGOpPhNhKbG70/owYXjKFENi5LoZKc8Y+c=
+
 addons:
   apt:
-    sources:
-    - debian-sid
+    update: true
+  homebrew:
+    update: true
+    packages:
+      - coreutils
+      - gnu-sed
+
 before_install:
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install --allow-unauthenticated -y cabal-install; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cabal update; fi
 - if [ "$TRAVIS_OS_NAME" = "linux" ]; then cabal v1-install ShellCheck; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then brew update; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then which gsed || brew install gnu-sed; fi
-- if [ "$TRAVIS_OS_NAME" = "osx" ]; then which gtimeout || brew install coreutils; fi
 - if [ "$TRAVIS_OS_NAME" = "osx" ]; then which bundle || gem install bundler; fi
 - bash --version
 - awk --version


### PR DESCRIPTION
# TL;DR

Travis CI tests are successfully passing for both 🐧 Linux & 🍏 OSX.

- [x] assertions
- [x] shellcheck
- [x] `style.pl`

## Changes

- [x] 💚 use latest shellcheck binary 🍏+🐧
  - no more `cabal` installs

- [x] 🔨 use `addons: homebrew` for 🍏 `darwin` (GNU) packages

    ```yaml
    addons:
    apt:
        update: true
    homebrew:
        update: true
        packages:
        - coreutils
        - gnu-sed
        - gnu-tar
        - grep
        - make
        - gawk
        - findutils
        - gnu-which
        - gnu-time
    ```

- [x] 🔨 🍏 add gnubin dirs to $PATH

  - `homebrew` decided to [remove `--with-default-names`][gnu-homebrew]

    ```bash
    if [ "$TRAVIS_OS_NAME" = "osx" ]; then
      if type brew &>/dev/null; then
        HOMEBREW_PREFIX=$(brew --prefix)  # add gnubin commands to PATH
        for d in ${HOMEBREW_PREFIX}/opt/*/libexec/gnubin; do export PATH=$d:$PATH; done
      fi
    fi
    ```

- [x] 👷 limit git clone depth (3)
- [x] 🔨 move `blah --version` debug commands to `before_script`
- [x] 💚 remove `cache: apt` because docs
  - https://docs.travis-ci.com/user/caching/#things-not-to-cache
- [ ] ⭕️ ~~set `dist: trusty` in matrix~~

[gnu-homebrew]: <https://discourse.brew.sh/t/why-was-with-default-names-removed/4405>
