### PR TITLE
Fix or silence remaining warnings with shellcheck v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Released: TBA.
 - [x] Fix typo in FAQ (#92, @gmasse)
 - [x] Fix Travis CI failure on src/templater.sh (@gmasse)
 - [x] Add magic variable which contains full command invocation
+- [x] Fix remaining warnings with shellcheck v0.7.0 (#107, @genesiscloud)
 
 ## v2.3.0
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ $ my_script some more args --blah
 - [OpenCoarrays](http://www.opencoarrays.org)
 - [Sourcery Institute](http://www.sourceryinstitute.org)
 - [Computational Brain Anatomy Laboratory](http://cobralab.ca/)
+- [Genesis Cloud](https://genesiscloud.com/)
 
 We are looking for endorsements! Are you also using b3bp? [Let us know](https://github.com/kvz/bash3boilerplate/issues/new?title=I%20use%20b3bp) and get listed.
 
@@ -165,6 +166,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [Giovanni Saponaro](https://github.com/gsaponaro) (feedback)
 - [Germain Masse](https://github.com/gmasse)
 - [A. G. Madi](https://github.com/warpengineer)
+- [Lukas Stockner](mailto:oss@genesiscloud.com)
 
 ## License
 

--- a/main.sh
+++ b/main.sh
@@ -47,7 +47,8 @@ fi
 __dir="$(cd "$(dirname "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")" && pwd)"
 __file="${__dir}/$(basename "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")"
 __base="$(basename "${__file}" .sh)"
-__invocation="$(printf %q "${__file}")$((($#)) && printf ' %q' "$@" || true)"
+# shellcheck disable=SC2034,SC2015
+__invocation="$(printf %q "${__file}")$( (($#)) && printf ' %q' "$@" || true)"
 
 # Define the environment variables (and their defaults) that this script depends on
 LOG_LEVEL="${LOG_LEVEL:-6}" # 7 = debug -> 0 = emergency
@@ -83,7 +84,7 @@ function __b3bp_log () {
   local color="${!colorvar:-${color_error}}"
   local color_reset="\\x1b[0m"
 
-  if [[ "${NO_COLOR:-}" = "true" ]] || ( [[ "${TERM:-}" != "xterm"* ]] && [[ "${TERM:-}" != "screen"* ]] ) || [[ ! -t 2 ]]; then
+  if [[ "${NO_COLOR:-}" = "true" ]] || { [[ "${TERM:-}" != "xterm"* ]] && [[ "${TERM:-}" != "screen"* ]]; } || [[ ! -t 2 ]]; then
     if [[ "${NO_COLOR:-}" != "false" ]]; then
       # Don't use colors on pipes or non-recognized terminals
       color=""; color_reset=""


### PR DESCRIPTION
SC2235: The warning/suggestion about the subshell was letigimate, so
the suggested fix is implemented.

SC2034: The variable __invocation is indeed unused, but it's supposed
to be there in case the script using bash3boilerplate wants to use it,
so this commit silences the warning.

SC1102: The warning about the parsing of $((( is legitimate, so the
suggested fix is implemented.

SC2015: While the warning is correct in general, here 'true' has no
side effects hence it can be silenced.

Fixes #107.