### PR TITLE
Fix read values only from the specified section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released: TBA.
 [Diff](https://github.com/kvz/bash3boilerplate/compare/v2.4.1...master).
 
 - [x] Capture correct error_code in err_report (#124, @eval)
+- [x] Fix read values only from the specified section (@rfuehrer)
 - [ ]
 
 ## v2.4.1

--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [A. G. Madi](https://github.com/warpengineer)
 - [Lukas Stockner](mailto:oss@genesiscloud.com)
 - [Gert Goet](https://github.com/eval)
+- [@rfuehrer](https://github.com/rfuehrer)
 
 
 ## License

--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -41,8 +41,7 @@ function ini_val() {
     section=""
   fi
 
-  local current
-  current=$(awk -F "${delim}" "/^${key}${delim}/ {for (i=2; i<NF; i++) printf \$i \" \"; print \$NF}" "${file}")
+  local current=$(sed -rn "/^\[/{h;d};G;s/^${key}(.*)=(.*)\n\[${section}\]$/\2/p" "${file}"|awk '{$1=$1};1')
 
   if [[ ! "${val}" ]]; then
     # get a value


### PR DESCRIPTION
Thanks for contributing to b3bp! As part of your PR, have you:

- [x] Added an item in [CHANGELOG.md](https://github.com/kvz/bash3boilerplate/blob/master/CHANGELOG.md) with attribution?
- [x] Added your name to the [README.md](https://github.com/kvz/bash3boilerplate/blob/master/README.md#authors)
- [ ] Linted your code? (`make test` should do the trick)

With the corrected awk/sed command, only keys from the specified section are now read - previously keys from other sections were determined. However, there is now a problem that values without section are not read anymore, because added keys without section are subordinated to the last section and therefore belong to the last section - but that's a different PR ;) (perhaps by specifying a default section)

functionality:
- determining the section (sed)
- determining the key (sed)
- ignore spaces around the separator (=) (sed)
- removing leading and trailing spaces from the value (awk)