### PR TITLE
Fix sed regular expression to be non-greedy

### DIFF
--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -30,7 +30,7 @@ function ini_val() {
   local file="${1:-}"
   local sectionkey="${2:-}"
   local val="${3:-}"
-  local delim=" = "
+  local delim="="
   local section=""
   local key=""
   local current=""
@@ -50,7 +50,7 @@ function ini_val() {
     section="${section_default}"
   fi
 
-  current=$(sed -En "/^\[/{h;d;};G;s/^${key}(.*)${delim}(.*)\n\[${section}\]$/\2/p" "${file}"|awk '{$1=$1};1')
+  current=$(sed -En "/^\[/{h;d;};G;s/^${key}([[:blank:]]*)${delim}(.*)\n\[${section}\]$/\2/p" "${file}"|awk '{$1=$1};1')
 
   if ! grep -q "\[${section}\]" ${file}; then
     # create section if not exists (empty line to seperate new section)

--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -39,7 +39,7 @@ function ini_val() {
 
   if [[ ! -f "${file}" ]]; then
     # touch file if not exists
-    touch ${file}
+    touch "${file}"
   fi
 
   # Split on . for section. However, section is optional
@@ -52,7 +52,7 @@ function ini_val() {
 
   current=$(sed -En "/^\[/{h;d;};G;s/^${key}([[:blank:]]*)${delim}(.*)\n\[${section}\]$/\2/p" "${file}"|awk '{$1=$1};1')
 
-  if ! grep -q "\[${section}\]" ${file}; then
+  if ! grep -q "\[${section}\]" "${file}"; then
     # create section if not exists (empty line to seperate new section)
     echo  >> "${file}"
     echo "[${section}]" >> "${file}"


### PR DESCRIPTION
According to the (non-standard) definition of INI files, values can take any character. For this reason, the value of a key may contain the character string of the separator. In the previous query, only the rightmost (last) part of the value oof a string containing the delimiter was returned, but not the entire value from the first delimiter.

This becomes relevant at the latest when the delimiter is changed to "=" or ":" and this delimiter is part of a value (e.g. hashes or cryptic values)

Reference: https://en.wikipedia.org/wiki/INI_file, see "Format" / "Keys"

Furthermore, there may be users who manually edit an INI file and align the delimiters and values of the keys with spaces or tabs so that the delimiters are aligned. The current version allows this only to a limited extent.

The following change includes reformulating the separator to a single character (=) and requesting the delimiter/value using any character in the [:blank:] definition. This means that any spaces or tabs following the key are not considered part of the key.

Among other things, this allows the following scenarios of key/value definitions (several samples; _=space;#=tabulator):
key=value
key=_value
key____=_________value
key__#__#_=_#_value
key#=#value
key###=_value
key=value_key=value_key2=value2#key=value3_done

Compatibility to ini files of the previous version of the script is given.

Note: Maybe same procedure as PR #128 . I assume that the linux test will also fail in this request. but since only the var definition and the regex have been changed, the problem will not be caused by this substitutions.

Checked scenarios:
-[x] create/read key from ini file not existing
-[x] create/read key in section not existing
-[x] create/update existing key/value in existing section
-[x] read key/value
-[x] tested linux platform (Linux xxxx 3.10.105 #24922 SMP Wed Jul 3 16:35:48 CST 2019 x86_64 GNU/Linux synology_cedarview_...)
-[x] tested mac platform (Darwin xxxx 19.2.0 Darwin Kernel Version 19.2.0: Sat Nov 9 03:47:04 PST 2019; root:xnu-6153.61.1~20/RELEASE_X86_64 x86_64)

