### PR TITLE
Add comment feature to ini files

### DIFF
--- a/src/ini_val.sh
+++ b/src/ini_val.sh
@@ -7,16 +7,17 @@
 #
 # Limitations:
 #
-#  - All keys inside the .ini file must be unique, regardless of the use of sections
+#  - All keys inside a section of the .ini file must be unique
+#  - Optional comment parameter for the creation of new entries
 #
 # Usage as a function:
 #
 #  source ini_val.sh
-#  ini_val data.ini connection.host 127.0.0.1
+#  ini_val data.ini connection.host 127.0.0.1 "Host name or IP address"
 #
 # Usage as a command:
 #
-#  ini_val.sh data.ini connection.host 127.0.0.1
+#  ini_val.sh data.ini connection.host 127.0.0.1 "Host name or IP address"
 #
 # Based on a template by BASH3 Boilerplate v2.4.1
 # http://bash3boilerplate.sh/#authors
@@ -30,7 +31,9 @@ function ini_val() {
   local file="${1:-}"
   local sectionkey="${2:-}"
   local val="${3:-}"
+  local comment="${4:-}"
   local delim="="
+  local comment_delim=";"
   local section=""
   local key=""
   local current=""
@@ -70,8 +73,16 @@ function ini_val() {
         section=${section_default}
       fi
       # add to section
-      RET="/\\[${section}\\]/a\\
+      if [[ ! "${comment}" ]]; then
+        # add new key/value without comment
+        RET="/\\[${section}\\]/a\\
 ${key}${delim}${val}"
+      else
+        # add new key/value with preceeding comment
+        RET="/\\[${section}\\]/a\\
+${comment_delim}[${key}] ${comment}\\
+${key}${delim}${val}"
+      fi
       sed -i.bak -e "${RET}" "${file}"
       # this .bak dance is done for BSD/GNU portability: http://stackoverflow.com/a/22084103/151666
       rm -f "${file}.bak"

--- a/test/fixture/ini_val.stdio
+++ b/test/fixture/ini_val.stdio
@@ -2,6 +2,7 @@
 exists
 127.0.0.1
 nginx, nodejs
+
 --> command: Replace three values in-place and show result
 [default]
 orphan = no more
@@ -11,10 +12,15 @@ host = 192.168.0.1
 
 [software]
 packages = vim
+
+[comment]
+;[command] this key is commented
+command=commented
 --> function: Read 3 values
 exists
 127.0.0.1
 nginx, nodejs
+
 --> function: Replace three values in-place and show result
 [default]
 orphan = no more
@@ -24,3 +30,7 @@ host = 192.168.0.1
 
 [software]
 packages = vim
+
+[comment]
+;[command] this key is commented
+command=commented

--- a/test/scenario/ini_val/run.sh
+++ b/test/scenario/ini_val/run.sh
@@ -17,11 +17,13 @@ echo "--> command: Read 3 values"
 bash "${__root}/src/ini_val.sh" ./dummy.ini orphan
 bash "${__root}/src/ini_val.sh" ./dummy.ini connection.host
 bash "${__root}/src/ini_val.sh" ./dummy.ini software.packages
+bash "${__root}/src/ini_val.sh" ./dummy.ini comment.command
 
 echo "--> command: Replace three values in-place and show result"
 bash "${__root}/src/ini_val.sh" ./dummy.ini orphan "no more"
 bash "${__root}/src/ini_val.sh" ./dummy.ini connection.host "192.168.0.1"
 bash "${__root}/src/ini_val.sh" ./dummy.ini software.packages "vim"
+bash "${__root}/src/ini_val.sh" ./dummy.ini comment.command "commented" "this key is commented"
 cat dummy.ini
 rm -f dummy.ini
 
@@ -35,10 +37,12 @@ echo "--> function: Read 3 values"
 ini_val ./dummy.ini orphan
 ini_val ./dummy.ini connection.host
 ini_val ./dummy.ini software.packages
+ini_val ./dummy.ini comment.command
 
 echo "--> function: Replace three values in-place and show result"
 ini_val ./dummy.ini orphan "no more"
 ini_val ./dummy.ini connection.host "192.168.0.1"
 ini_val ./dummy.ini software.packages "vim"
+ini_val ./dummy.ini comment.command "commented" "this key is commented"
 cat dummy.ini
 rm -f dummy.ini


### PR DESCRIPTION
Following PR inserts the function of an optional fourth parameter in the function ini_val() When **new INI entries are inserted** into an ini file, a comment can now be added to the new entry. The following call

```
ini_val "file.ini" "section.key" "value" "comment"
```

now the following ini entries are written

```
[section]
;[key] comment
key=value
```

The function is compatible with previous versions. A set comment cannot be overwritten/changed afterwards!

The PR also contains customized test scenarios that check the setting and reading of values created with comments.