### PR TITLE
Resolve symlinks to find __origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Released: TBA.
 [Diff](https://github.com/kvz/bash3boilerplate/compare/v2.4.2...master).
 
 - [x] Add feature to edit/update comments in ini file (#132, @rfuehrer)
+- [x] New magic variable `__origin` when called via symlink (@efelon)
 
 ## v2.4.2
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ We are looking for endorsements! Are you also using b3bp? [Let us know](https://
 - [Lukas Stockner](mailto:oss@genesiscloud.com)
 - [Gert Goet](https://github.com/eval)
 - [@rfuehrer](https://github.com/rfuehrer)
+- [@efelon](https://github.com/efelon)
 
 
 ## License

--- a/main.sh
+++ b/main.sh
@@ -47,6 +47,7 @@ fi
 __dir="$(cd "$(dirname "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")" && pwd)"
 __file="${__dir}/$(basename "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")"
 __base="$(basename "${__file}" .sh)"
+__origin="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[${__b3bp_tmp_source_idx:-0}]}")")" && pwd)"
 # shellcheck disable=SC2034,SC2015
 __invocation="$(printf %q "${__file}")$( (($#)) && printf ' %q' "$@" || true)"
 
@@ -412,6 +413,7 @@ info "__i_am_main_script: ${__i_am_main_script}"
 info "__file: ${__file}"
 info "__dir: ${__dir}"
 info "__base: ${__base}"
+info "__origin: ${__origin}"
 info "OSTYPE: ${OSTYPE}"
 
 info "arg_f: ${arg_f}"


### PR DESCRIPTION
I propose another magic variable `__origin` which can be used for all dependencies. It would be the same as `__dir` except when called via symlink.

# Context

I usually place bash scripts in `/opt/myscript/myscript.sh` and use aliases. But if they are of good use to other users I would like to create a symlink to `/usr/local/bin/myscript`. Here I noticed that `__dir` would give me the directory of the symlink rather the one from the origin `/opt/myscript`. One may or may not have some dependencies at the origin which would not be found.

I read some time about the usage of `realpath` vs `readlink -f`, where my conclusion for now is to stick with readlink.

# Example

`cd /opt && git clone https://github.com/kvz/bash3boilerplate.git`
`LOG_LEVEL=7 /opt/bash3boilerplate/main.sh -f testp`

> 2022-03-16 15:56:24 UTC [     info] __i_am_main_script: 1
2022-03-16 15:56:24 UTC [     info] __file: /opt/bash3boilerplate/main.sh
2022-03-16 15:56:24 UTC [     info] __dir: `/opt/bash3boilerplate`
2022-03-16 15:56:24 UTC [     info] __base: main

`ln -s /opt/bash3boilerplate/main.sh /opt/run`

`LOG_LEVEL=7 /opt/run -f testp`

# Before the change

> 2022-03-16 15:53:40 UTC [     info] __i_am_main_script: 1
2022-03-16 15:53:40 UTC [     info] __file: /opt/run
2022-03-16 15:53:40 UTC [     info] __dir: `/opt`
2022-03-16 15:53:40 UTC [     info] __base: run

# After the change

`LOG_LEVEL=7 /opt/run -f testp`

> 2022-03-16 16:47:40 UTC [     info] __i_am_main_script: 1
2022-03-16 16:47:41 UTC [     info] __file: /opt/run
2022-03-16 16:47:41 UTC [     info] __dir: /opt
2022-03-16 16:47:41 UTC [     info] __base: run
2022-03-16 16:47:41 UTC [     info] `__origin: /opt/bash3boilerplate`