### PR TITLE
Update official Actions to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 18.x
       - name: Install macOS test dependencies
@@ -43,7 +43,7 @@ jobs:
   ci-bash3-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
       - name: Test In Docker (Bash 3.2.57)

--- a/test/shfmt.sh
+++ b/test/shfmt.sh
@@ -40,14 +40,7 @@ __cleanup_webi_envman() {
     fi
 
     tmp="$(mktemp)"
-    awk -v marker="${marker}" -v comment="${comment}" '
-      {
-        if ($0 == marker || $0 == comment) {
-          next
-        }
-        print
-      }
-    ' "${file}" >"${tmp}"
+    grep -Fvx -e "${marker}" -e "${comment}" "${file}" >"${tmp}" || true
     mv "${tmp}" "${file}"
     echo "Removed envman shell hook from ${file}"
   done
@@ -65,7 +58,7 @@ __cleanup_webi_envman() {
   if [[ -L "${HOME}/.local/bin/shfmt" ]]; then
     local linked
     linked="$(readlink -f "${HOME}/.local/bin/shfmt" || true)"
-    if [[ "${linked}" == "${HOME}/.local/opt/shfmt-"*"/bin/shfmt" ]]; then
+    if [[ "${linked}" = "${HOME}/.local/opt/shfmt-"*"/bin/shfmt" ]]; then
       rm -f "${HOME}/.local/bin/shfmt"
       rm -rf "$(dirname "$(dirname "${linked}")")"
       echo "Removed old webi-managed shfmt"


### PR DESCRIPTION
Why

GitHub is deprecating the Node.js 20 runtime used by older official JavaScript actions. Updating the official Actions major versions keeps CI on the supported action runtime without changing the project toolchain.

What changed

- Updated `actions/checkout` from `v4` to `v6`.
- Updated `actions/setup-node` from `v4` to `v6`.
- Cleaned up two existing `test/shfmt.sh` style-lint violations that CI surfaced after the action update rerun.

Verification

- `ruby -e 'require "yaml"; Dir[".github/workflows/*.{yml,yaml}"].each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `git diff --check`
- `rg -n "actions/(checkout|setup-node)@" .github/workflows`
- `test/style.pl test/shfmt.sh`
- `test/shfmt.sh lint`